### PR TITLE
Fized README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This program seems simple.
 It's only complex because it's made with x86_64 assembly.
 
-C++ equivalent: `cout << argv[1] << "^2 = " << argv[1] * argv[1] << endl;`
+C++ equivalent: `std::cout << argv[1] << "^2 = " << argv[1] * argv[1];`
 
 ## Requirements
 


### PR DESCRIPTION
fixed **ERRONEOUS** C++ syntax (missing namespace and removed 'endl' because C++ can flush the output buffer on its own and a newline is better anyways)

(this is a joke pls don't take it seriously I'M A NICE PERSON)